### PR TITLE
Fix Slack end point failing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
  "itoa",
  "ryu",

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -67,18 +67,20 @@ fn get_port() -> u16 {
 }
 
 #[derive(FromForm)]
+#[form(lenient)]
 pub struct SlackCommand {
-    // pub token: String,
-    // pub team_id: String,
-    // pub team_domain: String,
-    // pub channel_id: String,
-    // pub channel_name: String,
+    pub token: String,
+    pub team_id: String,
+    pub team_domain: String,
+    pub channel_id: String,
+    pub channel_name: String,
     pub user_id: String,
-    // pub user_name: String,
-    // pub command: String,
+    pub user_name: String,
+    pub command: String,
     pub text: String,
-    // pub response_url: String,
-    // pub trigger_id: String,
+    pub api_app_id: String,
+    pub response_url: String,
+    pub trigger_id: String,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
Slack added a new field to their request. Rocket by default expects
strict message bodies.

 * Add new field to SlackCommand.
 * Change parsing to be lienient for the future.